### PR TITLE
Header conformance fixes

### DIFF
--- a/src/uchardet.h
+++ b/src/uchardet.h
@@ -34,8 +34,8 @@
  * the terms of any one of the MPL, the GPL or the LGPL.
  *
  * ***** END LICENSE BLOCK ***** */
-#ifndef ___UCHARDET_H___
-#define ___UCHARDET_H___
+#ifndef UCHARDET_H___
+#define UCHARDET_H___
 
 #ifdef __cplusplus
 extern "C" {
@@ -43,13 +43,13 @@ extern "C" {
 
 #include <stddef.h>
 
-typedef void * uchardet_t;
+typedef struct uchardet * uchardet_t;
 
 /**
  * Create an encoding detector.
  * @return a handle of a instance of uchardet
  */
-uchardet_t uchardet_new();
+uchardet_t uchardet_new(void);
 
 /**
  * Delete an encoding detector.


### PR DESCRIPTION
Identifiers starting with __ are reserved for the system - user code
(including non-system libraries) must not define them.

A function which takes no parameters is declared with "(void)". In C, an
empty parameter list means that any number of parameters with
unspecified types is allowed, which is not what we want in this case.
Another reason to fix this is that compilers often warn if this legacy
feature is used, which is bothersome for API users.

Additionally, use an opaque struct as underlying type for uchardet_t.
This facilitates type-checking, as it's harder to confuse with other
types, especially in C. This is not strictly a conformance issue, but
still a nice change. Note that this is neither an API or an ABI change.