### PR TITLE
(void) and () empty arguments are different in C.

### DIFF
--- a/src/uchardet.cpp
+++ b/src/uchardet.cpp
@@ -73,7 +73,7 @@ public:
     }
 };
 
-uchardet_t uchardet_new()
+uchardet_t uchardet_new(void)
 {
     return reinterpret_cast<uchardet_t> (new HandleUniversalDetector());
 }


### PR DESCRIPTION
This fixes the following warning when including uchardet.h in C source,
built with -Wstrict-prototypes:
`uchardet.h:52:1: warning: function declaration isn't a prototype`

We want to use uchardet in gtksourceview (used for instance for gedit):
https://bugzilla.gnome.org/show_bug.cgi?id=669448
I had this warning when compiling with a define to uchardet.h.