### PR TITLE
do not use std::string which breaks c++ abi

### DIFF
--- a/src/uchardet.cpp
+++ b/src/uchardet.cpp
@@ -35,41 +35,47 @@
  *
  * ***** END LICENSE BLOCK ***** */
 #include "uchardet.h"
+#include <string.h>
+#include <stdlib.h>
 #include "nscore.h"
 #include "nsUniversalDetector.h"
-#include <string>
-
-using std::string;
 
 class HandleUniversalDetector : public nsUniversalDetector
 {
 protected:
-	string m_charset;
+    char *m_charset;
 
 public:
     HandleUniversalDetector()
     : nsUniversalDetector(NS_FILTER_ALL)
+    , m_charset(0)
     {
-        m_charset = "";
     }
 
     virtual ~HandleUniversalDetector()
-    {}
+    {
+        if (m_charset)
+            free(m_charset);
+    }
 
     virtual void Report(const char* charset)
     {
-        m_charset = charset;
+        if (m_charset)
+            free(m_charset);
+        m_charset = strdup(charset);
     }
 
     virtual void Reset()
     {
         nsUniversalDetector::Reset();
-        m_charset = "";
+        if (m_charset)
+            free(m_charset);
+        m_charset = strdup("");
     }
 
     const char* GetCharset() const
     {
-        return m_charset.c_str();
+        return m_charset;
     }
 };
 


### PR DESCRIPTION
Some stl types can break abi. If the program is built with g++ 5, and libstdc++ on the target platform is g++ 4.x, then it can not run